### PR TITLE
Logout functionality

### DIFF
--- a/ZeroFrame.gd
+++ b/ZeroFrame.gd
@@ -266,6 +266,10 @@ func stop_zeronet():
 	res.error = ZeroFrameCore.stop_zeronet()
 	return res
 
+# Ensure ZeroNet is stopped if the game is exited
+func _exit_tree():
+	ZeroFrameCore.stop_zeronet()
+
 # ---------------- Misc ---------------- #
 
 func connect_to_site(site_address: String) -> Result:

--- a/ZeroFrame.gd
+++ b/ZeroFrame.gd
@@ -60,8 +60,8 @@ func get_private_key(username: String, provider: int = PROVIDER_ZEROID) -> Resul
 	return res
 
 func logout(provider: int = PROVIDER_ZEROID) -> Result:
-	# TODO
 	var res = Result.new()
+	res.error = ZeroFrameCore.logout()
 	return res
 
 func is_logged_in(provider: int = PROVIDER_ZEROID) -> Result:
@@ -250,6 +250,20 @@ func remove_data(key: String) -> Result:
 		res.error = r.error
 		return res
 
+	return res
+
+# ---------- Daemon Management --------- #
+
+func start_zeronet():
+	"""Start an internal ZeroNet daemon"""
+	var res = Result.new()
+	res.error = ZeroFrameCore.start_zeronet()
+	return res
+
+func stop_zeronet():
+	"""Stop an internal ZeroNet daemon"""
+	var res = Result.new()
+	res.error = ZeroFrameCore.stop_zeronet()
 	return res
 
 # ---------------- Misc ---------------- #

--- a/ZeroFrameCore.gd
+++ b/ZeroFrameCore.gd
@@ -379,9 +379,9 @@ func login_zeroid(private_key):
 	return result[0] == "done"
 
 # Log the user out of all accounts
-# Achieves this goal in different ways depending on whether we're running in
+# It achieves this goal in different ways depending on whether we're running in
 # Multiuser mode or not.
-# If in Multiuser mode, we simply remove the master seed from subsequent request
+# If in Multiuser mode, we simply remove the master seed from subsequent requests
 # If not, we must remove the master seed from the users.json file
 func logout():
 	if _multiuser_mode:

--- a/ZeroFrameCore.gd
+++ b/ZeroFrameCore.gd
@@ -72,7 +72,7 @@ func _init(config_file=config_file_path, use_config_file=true, daemon_address="1
 
 func _log(args):
 	"""Log out an array of arguments in a consistent manner"""
-	print("[ZCore] ", *args)
+	print("[ZCore] ", args)
 
 func start_zeronet():
 	if not _ZeroNet_addon:

--- a/ZeroFrameCore.gd
+++ b/ZeroFrameCore.gd
@@ -68,11 +68,15 @@ func _init(config_file=config_file_path, use_config_file=true, daemon_address="1
 
 	# Load ZeroNet addon if not using an external daemon
 	if not _external_daemon:
-		_ZeroNet_addon = load(zeronet_addon_path + "ZeroNet.gd")
+		_ZeroNet_addon = load(zeronet_addon_path + "ZeroNet.gd").new()
 
 func _log(args):
 	"""Log out an array of arguments in a consistent manner"""
-	print("[ZCore] ", args)
+	printraw("[ZCore] ")
+	for arg in args:
+		printraw(arg + " ")
+		
+	printraw("\n")
 
 func start_zeronet():
 	if _external_daemon:
@@ -387,8 +391,6 @@ func logout():
 	if _external_daemon:
 		return ("Cannot logout from an external ZeroNet instance without Multiuser" +
 		        "mode enabled (and the Multiuser plugin enabled on the daemon)")
-
-	# Remove the master seed from users.json manually
 	
 	# Check the file exists
 	var users_file_path = zeronet_addon_path + "ZeroNet/data/users.json"
@@ -397,7 +399,7 @@ func logout():
 		return "Path to ZeroNet users file does not exist: " + users_file_path
 
 	# Remove all content in the file
-	users_file.open(users_file_path)
+	users_file.open(users_file_path, File.WRITE)
 	users_file.store_string("{}")
 	users_file.close()
 

--- a/ZeroFrameCore.gd
+++ b/ZeroFrameCore.gd
@@ -75,15 +75,21 @@ func _log(args):
 	print("[ZCore] ", args)
 
 func start_zeronet():
-	if not _ZeroNet_addon:
+	if _external_daemon:
 		return "Option external_daemon has been set to true. Refusing to start"
+
+	if _ZeroNet_addon == null:
+		return "Unable to load ZeroNet addon. Ensure it is stored at addons/ZeroNet"
 
 	# Start ZeroNet addon
 	_ZeroNet_addon.start(_daemon_port)
 
 func stop_zeronet():
-	if not _ZeroNet_addon:
+	if _external_daemon:
 		return "Option external_daemon has been set to true. Refusing to stop"
+
+	if _ZeroNet_addon == null:
+		return "Unable to load ZeroNet addon. Ensure it is stored at addons/ZeroNet"
 
 	# Stop ZeroNet addon
 	_ZeroNet_addon.stop()

--- a/ZeroFrameCore.gd
+++ b/ZeroFrameCore.gd
@@ -70,9 +70,8 @@ func _init(config_file=config_file_path, use_config_file=true, daemon_address="1
 	if not _external_daemon:
 		_ZeroNet_addon = load(zeronet_addon_path + "ZeroNet.gd")
 
-# Logger function. For consistent logging printout
-# args is an array of items to print out
 func _log(args):
+	"""Log out an array of arguments in a consistent manner"""
 	print("[ZCore] ", *args)
 
 func start_zeronet():

--- a/ZeroFrameCore.gd
+++ b/ZeroFrameCore.gd
@@ -99,7 +99,7 @@ func _process(delta):
 			timeout_counter = 0
 			timeout_limit = 0
 
-	if _ws_client.get_connection_status() != NetworkedMultiplayerPeer.CONNECTION_DISCONNECTED:
+	if _ws_client != null and _ws_client.get_connection_status() != NetworkedMultiplayerPeer.CONNECTION_DISCONNECTED:
 		_ws_client.poll()
 		if _ws_client.get_peer(1).get_available_packet_count() > 0:
 			var response = JSON.parse(_ws_client.get_peer(1).get_packet().get_string_from_utf8()).result

--- a/ZeroFrameCore.gd
+++ b/ZeroFrameCore.gd
@@ -128,15 +128,15 @@ func _process(delta):
 
 # Creates a new WebSocket client
 func _new_ws_client():
-	_ws_client = WebSocketClient.new()
+	var new_client = WebSocketClient.new()
 
 	# Websocket client signals
-	_ws_client.connect("connection_established", self, "_ws_connection_established")
-	_ws_client.connect("connection_succeeded", self, "_ws_connection_established")
-	_ws_client.connect("connection_error", self, "_ws_connection_error")
-	_ws_client.connect("server_close_request", self, "_ws_server_close_request")
+	new_client.connect("connection_established", self, "_ws_connection_established")
+	new_client.connect("connection_succeeded", self, "_ws_connection_established")
+	new_client.connect("connection_error", self, "_ws_connection_error")
+	new_client.connect("server_close_request", self, "_ws_server_close_request")
 
-	return _ws_client
+	return new_client
 
 # Searches through a dictionary of users for an auth address
 # Helper function for ZeroID registration

--- a/config.cfg
+++ b/config.cfg
@@ -5,5 +5,5 @@ max_in_buffer_kb="64"
 zeronet_port="43110"
 automatic_buffer_kb=false
 site_address=""
-multiuser_mode=False
-external_daemon=False
+multiuser_mode=false
+external_daemon=false


### PR DESCRIPTION
Ability to log out of all ZeroNet accounts. This is currently only possible if you're running ZeroNet from within Godot, and not with external ZeroNet daemons (at least until Godot 3.2 with customizable websocket headers drops).

There's some other crap included in this PR (logging fixes, starting ZeroNet addon, etc) which was necessary to test this stuff. Please do give it a glance over as well.